### PR TITLE
Request gzip responses.

### DIFF
--- a/porc/resource.py
+++ b/porc/resource.py
@@ -48,7 +48,7 @@ class Resource(object):
 
         header_names= set(name.lower() for name in headers)
         if "accept-encoding" not in header_names:
-            headers['accept-encoding'] = 'gzip'
+            headers['Accept-Encoding'] = 'gzip'
 
         opts = dict(headers=headers)
         session = self.async_session if self.use_async else self.session

--- a/porc/resource.py
+++ b/porc/resource.py
@@ -46,6 +46,7 @@ class Resource(object):
 
         uri = urljoin(self.uri, path)
 
+        headers['Accept-Encoding'] = 'gzip'
         opts = dict(headers=headers)
         session = self.async_session if self.use_async else self.session
         # normalize body according to method and type

--- a/porc/resource.py
+++ b/porc/resource.py
@@ -46,7 +46,10 @@ class Resource(object):
 
         uri = urljoin(self.uri, path)
 
-        headers['Accept-Encoding'] = 'gzip'
+        header_names= set(name.lower() for name in headers)
+        if "accept-encoding" not in header_names:
+            headers['accept-encoding'] = 'gzip'
+
         opts = dict(headers=headers)
         session = self.async_session if self.use_async else self.session
         # normalize body according to method and type


### PR DESCRIPTION
Adds an 'Accept-Encoding: gzip' so responses will be compressed. The requests module will automatically decompress it: http://www.python-requests.org/en/latest/community/faq/#encoded-data

It seems that compressing the actual request data is not as easy, so not including that here.